### PR TITLE
fix(ci): running on every new review comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: Default CI
 on:
   pull_request:
     types: [labeled, review_requested]
-  pull_request_review:
-    types: [submitted]
 
 # All in one job to reduce GitHub-actions minutes used.
 # Only run if "ready for review" label exists on PR.


### PR DESCRIPTION
# Pull request summary

CI no longer runs on PR review submit.
(but will still run when "ready for review" label is first added, and when review is requested.)
This fixes error where CI would run on every new comment added within a review.

## Linked completed or partially completed issues
closes #57 


## Checklist
**All boxes checked before merging**

**Only ticked off by the PR AUTHOR**
- [x] I've added tests that cover any source code changes/additions made,
Alternatively, I've ensured there is an issue describing which code needs to be covered by tests
- [x] All tests pass
- [x] New features added and changes made have up-to-date (in-code) documentation
- [x] I've tried my best to follow the commit message convention
- [x] I've autoformatted my code changes
- [x] I've added the `ready for review` label to the PR

**Only ticked off by the CODE REVIEWER**
The code has been reviewed, and any requested changes have been implemented by the PR author and accepted by the code reviewers
- [ ] Reviewer A
- [ ] Reviewer B

**Check again that all CI checks are passing before merging PR**
