### PR TITLE
Set ci to run on pushes to pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Default CI
 
 on:
   pull_request:
-    types: [push]
+    types: [opened, synchronize, reopened]
 
 # All in one job to reduce GitHub-actions minutes used.
 # Only run if "ready for review" label exists on PR.


### PR DESCRIPTION
# Pull request summary

CI would now run whenever a push is made to a branch that has an open PR, this also means that pushing multiple commits at once will only trigger the CI once on the most recent commit.


## Linked completed or partially completed issues


## Checklist
**All boxes checked before merging**

**Ticked off by the PR AUTHOR**
- [x] I've added tests that cover any source code changes/additions made.
Alternatively, I've ensured there is an issue describing which code needs to be covered by tests
- [x] All tests pass
- [x] New features added and changes made have up-to-date (in-code) documentation
- [x] I've tried my best to follow the commit message convention
- [x] I've autoformatted my code changes and followed the code standards
- [x] I've added the `ready for review` label,
and (if applicable) the `backend` or `frontend` label to the PR


Before merging changes, the code should have been reviewed,
and any requested changes have been implemented by the PR author
and accepted by the code reviewers

**Check again that all CI checks are passing before merging PR**
