### PR TITLE
fix(backend): server broken /quit due to handleQuit not having access to stop

### DIFF
--- a/backend/core/server/server.go
+++ b/backend/core/server/server.go
@@ -49,7 +49,6 @@ const (
 type serverFuncParams struct {
 	writer io.Writer
 	db     *sql.DB
-	stop   context.CancelFunc
 }
 
 // startContainer start the database container using
@@ -191,7 +190,7 @@ func Run(args []string) {
 
 	queryHandler := func(writer http.ResponseWriter, request *http.Request) {
 		enableCORS(&writer)
-		serverParams := serverFuncParams{writer: writer, db: db, stop: stop}
+		serverParams := serverFuncParams{writer: writer, db: db}
 
 		switch html.EscapeString(request.URL.Path) {
 		case _ALL_:
@@ -201,7 +200,7 @@ func Run(args []string) {
 		case _ADD_:
 			handleAdd(serverParams, request.URL.Query()["p"])
 		case _QUIT_:
-			handleQuit(serverParams)
+			handleQuit(serverParams, stop)
 		}
 	}
 
@@ -326,9 +325,9 @@ func handleAdd(serverParams serverFuncParams, paths []string) {
 
 // handleQuit handles a /quit request by initiating the shutdown process
 // by cancelling the server context.
-func handleQuit(serverParams serverFuncParams) {
+func handleQuit(serverParams serverFuncParams, stop context.CancelFunc) {
 	_, err := fmt.Fprintf(serverParams.writer, "Shutting down\n")
 	checkIOError(err)
 
-	serverParams.stop()
+	stop()
 }


### PR DESCRIPTION
# Pull request summary

/quit command in server was broken due to the stop function not being passed in serverparams. To be a bit cleaner I removed stop from the serverParams struct and it is passed as a param to handleQuit


## Linked completed or partially completed issues
*(You can write "closes #ISSUE_NUMBER" to autoclose when PR gets merged.)*


## Checklist
**All boxes checked before merging**

**Ticked off by the PR AUTHOR**
- [x] I've added tests that cover any source code changes/additions made.
Alternatively, I've ensured there is an issue describing which code needs to be covered by tests
- [x] All tests pass
- [x] New features added and changes made have up-to-date (in-code) documentation
- [x] I've tried my best to follow the commit message convention
- [x] I've autoformatted my code changes and followed the code standards
- [x] I've added the `ready for review` label,
and (if applicable) the `backend` or `frontend` label to the PR


Before merging changes, the code should have been reviewed,
and any requested changes have been implemented by the PR author
and accepted by the code reviewers

**Check again that all CI checks are passing before merging PR**
